### PR TITLE
Avoid auto generation of IdP entity ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN echo "<?php" > /var/www/simplesamlphp/metadata/shib13-sp-remote.php
 COPY config/simplesamlphp/config.php /var/www/simplesamlphp/config
 COPY config/simplesamlphp/authsources.php /var/www/simplesamlphp/config
 COPY config/simplesamlphp/saml20-sp-remote.php /var/www/simplesamlphp/metadata
+COPY config/simplesamlphp/saml20-idp-hosted.php /var/www/simplesamlphp/metadata
 COPY config/simplesamlphp/server.crt /var/www/simplesamlphp/cert/
 COPY config/simplesamlphp/server.pem /var/www/simplesamlphp/cert/
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Name|Required/Optional|Description
 `SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE`|Requried|The assertion consumer service of your SP.
 `SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE`|Optional|The single logout url of your SP.
 `SIMPLESAMLPHP_IDP_ADMIN_PASSWORD`|Optional|The password of admin of this IdP. Default is `secret`.
+`SIMPLESAMLPHP_IDP_ENTITY_ID`|Optional|The entity ID of this IdP. Default is ` __DYNAMIC:1__`, the entity ID will be generated automatically.
 `SIMPLESAMLPHP_IDP_SECRET_SALT`|Optional|This is a secret salt used by this IdP when it needs to generate a secure hash of a value. Default is `defaultsecretsalt`.
 `SIMPLESAMLPHP_IDP_SESSION_DURATION_SECONDS`|Optional|This value is the duration of the session of this IdP in seconds.
 

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * SAML 2.0 IdP configuration for SimpleSAMLphp.
+ *
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
+ */
+
+$metadata['__DYNAMIC:1__'] = array(
+	/*
+	 * The hostname of the server (VHOST) that will use this SAML entity.
+	 *
+	 * Can be '__DEFAULT__', to use this entry by default.
+	 */
+	'host' => '__DEFAULT__',
+
+	// X.509 key and certificate. Relative to the cert directory.
+	'privatekey' => '/conf/server.pem',
+	'certificate' => '/conf/server.crt',
+
+	/*
+	 * Authentication source to use. Must be one that is configured in
+	 * 'config/authsources.php'.
+	 */
+	'auth' => 'example-userpass',
+
+	/*
+	 * WARNING: SHA-1 is disallowed starting January the 1st, 2014.
+	 *
+	 * Uncomment the following option to start using SHA-256 for your signatures.
+	 * Currently, SimpleSAMLphp defaults to SHA-1, which has been deprecated since
+	 * 2011, and will be disallowed by NIST as of 2014. Please refer to the following
+	 * document for more information:
+	 *
+	 * http://csrc.nist.gov/publications/nistpubs/800-131A/sp800-131A.pdf
+	 *
+	 * If you are uncertain about service providers supporting SHA-256 or other
+	 * algorithms of the SHA-2 family, you can configure it individually in the
+	 * SP-remote metadata set for those that support it. Once you are certain that
+	 * all your configured SPs support SHA-2, you can safely remove the configuration
+	 * options in the SP-remote metadata set and uncomment the following option.
+	 *
+	 * Please refer to the IdP hosted reference for more information.
+	 */
+	//'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+
+	/* Uncomment the following to use the uri NameFormat on attributes. */
+	/*
+	'attributes.NameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+	'authproc' => array(
+		// Convert LDAP names to oids.
+		100 => array('class' => 'core:AttributeMap', 'name2oid'),
+	),
+	*/
+
+	/*
+	 * Uncomment the following to specify the registration information in the
+	 * exported metadata. Refer to:
+     * http://docs.oasis-open.org/security/saml/Post2.0/saml-metadata-rpi/v1.0/cs01/saml-metadata-rpi-v1.0-cs01.html
+	 * for more information.
+	 */
+	/*
+	'RegistrationInfo' => array(
+		'authority' => 'urn:mace:example.org',
+		'instant' => '2008-01-17T11:28:03Z',
+		'policies' => array(
+			'en' => 'http://example.org/policy',
+			'es' => 'http://example.org/politica',
+		),
+	),
+	*/
+);

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -5,7 +5,7 @@
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
  */
 
-$metadata['__DYNAMIC:1__'] = array(
+$metadata[getenv('SIMPLESAMLPHP_IDP_ENTITY_ID') ?: '__DYNAMIC:1__'] = array(
 	/*
 	 * The hostname of the server (VHOST) that will use this SAML entity.
 	 *


### PR DESCRIPTION
Added saml20-idp-hosted.php IdP configuration to avoid auto generation of IdP entity ID by specifying SIMPLESAMLPHP_IDP_ENTITY_ID environment variable.