### PR TITLE
Use absolute path to mount authsources.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ docker run --name=idp \
   -e SIMPLESAMLPHP_SP_ENTITY_ID=http://app.example.com \
   -e SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=http://localhost/simplesaml/module.php/saml/sp/saml2-acs.php/test-sp \
   -e SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE=http://localhost/simplesaml/module.php/saml/sp/saml2-logout.php/test-sp \
-  -v authsources.php:/var/www/simplesamlphp/config/authsources.php \
+  -v $PWD/authsources.php:/var/www/simplesamlphp/config/authsources.php \
   -d kenchan0130/simplesamlphp
 ```
 


### PR DESCRIPTION
As explained in https://stackoverflow.com/questions/42248198/how-to-mount-a-single-file-in-a-volume#42260979 this is needed and it will fail otherwise with `source /var/lib/docker/overlay2/f17af3168be07207fc0823e339eeffa3da928070a4ac0471f006730e09c02118/merged/var/www/simplesamlphp/config/authsources.php is not directory.`