### PR TITLE
Allow `baseurlpath` to be configured with an env var for when running behind a reverse proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Name|Required/Optional|Description
 `SIMPLESAMLPHP_IDP_ADMIN_PASSWORD`|Optional|The password of admin of this IdP. Default is `secret`.
 `SIMPLESAMLPHP_IDP_SECRET_SALT`|Optional|This is a secret salt used by this IdP when it needs to generate a secure hash of a value. Default is `defaultsecretsalt`.
 `SIMPLESAMLPHP_IDP_SESSION_DURATION_SECONDS`|Optional|This value is the duration of the session of this IdP in seconds.
-`SIMPLESAMLPHP_BASE_URL_PATH`|Optional|This value allows you to override the base URL. Valuable for setting an `https://` base url behind a reverse proxy. **IMPORTANT** This url _must_ still end with `/simplesaml/` example: `https://my.proxy.com/simplesaml/` [Read more here](https://github.com/kenchan0130/docker-simplesamlphp/blob/master/config/simplesamlphp/config.php#L9-L24).
+`SIMPLESAMLPHP_BASE_URL_PATH`|Optional|This value allows you to override the base URL. Valuable for setting an `https://` base url behind a reverse proxy. **IMPORTANT** This url _must_ still end with `/simplesaml/` example: `https://my.proxy.com/simplesaml/` [Read more here](https://github.com/kenchan0130/docker-simplesamlphp/blob/master/config/simplesamlphp/config.php#L9-L24). Default is `simplesaml/`.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Name|Required/Optional|Description
 `SIMPLESAMLPHP_IDP_ADMIN_PASSWORD`|Optional|The password of admin of this IdP. Default is `secret`.
 `SIMPLESAMLPHP_IDP_SECRET_SALT`|Optional|This is a secret salt used by this IdP when it needs to generate a secure hash of a value. Default is `defaultsecretsalt`.
 `SIMPLESAMLPHP_IDP_SESSION_DURATION_SECONDS`|Optional|This value is the duration of the session of this IdP in seconds.
-`SIMPLESAMLPHP_BASE_URL_PATH`|Optional|This value allows you to override the base URL. Valuable for setting an `https://` base url behind a reverse proxy. **IMPORTANT** This url _must_ still end with `/simplesaml/` example: `https://my.proxy.com/simplesaml/` [Read more here](https://github.com/kenchan0130/docker-simplesamlphp/blob/master/config/simplesamlphp/config.php#L9-L24). Default is `simplesaml/`.
+`SIMPLESAMLPHP_IDP_BASE_URL`|Optional|This value allows you to override the base URL. Valuable for setting an `https://` base url behind a reverse proxy. **If you set this variable, please end it with a trailing `/`** example: `https://my.proxy.com/` Default is `` (empty string).
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Name|Required/Optional|Description
 `SIMPLESAMLPHP_IDP_ADMIN_PASSWORD`|Optional|The password of admin of this IdP. Default is `secret`.
 `SIMPLESAMLPHP_IDP_SECRET_SALT`|Optional|This is a secret salt used by this IdP when it needs to generate a secure hash of a value. Default is `defaultsecretsalt`.
 `SIMPLESAMLPHP_IDP_SESSION_DURATION_SECONDS`|Optional|This value is the duration of the session of this IdP in seconds.
+`SIMPLESAMLPHP_BASE_URL_PATH`|Optional|This value allows you to override the base URL. Valuable for setting an `https://` base url behind a reverse proxy. **IMPORTANT** This url _must_ still end with `/simplesaml/` example: `https://my.proxy.com/simplesaml/` [Read more here](https://github.com/kenchan0130/docker-simplesamlphp/blob/master/config/simplesamlphp/config.php#L9-L24).
 
 ## Advanced Usage
 

--- a/config/simplesamlphp/config.php
+++ b/config/simplesamlphp/config.php
@@ -21,7 +21,7 @@ $config = array(
      * external url, no matter where you come from (direct access or via the
      * reverse proxy).
      */
-    'baseurlpath' => getenv('SIMPLESAMLPHP_BASE_URL_PATH') ?: 'simplesaml/',
+    'baseurlpath' => getenv('SIMPLESAMLPHP_IDP_BASE_URL') ?: '' . 'simplesaml/',
     'certdir' => 'cert/',
     'loggingdir' => 'log/',
     'datadir' => 'data/',

--- a/config/simplesamlphp/config.php
+++ b/config/simplesamlphp/config.php
@@ -21,7 +21,7 @@ $config = array(
      * external url, no matter where you come from (direct access or via the
      * reverse proxy).
      */
-    'baseurlpath' => 'simplesaml/',
+    'baseurlpath' => getenv('SIMPLESAMLPHP_BASE_URL_PATH') ?: 'simplesaml/',
     'certdir' => 'cert/',
     'loggingdir' => 'log/',
     'datadir' => 'data/',


### PR DESCRIPTION
For cases when we need to run this container behind a reverse proxy - i.e. the reverse proxy provides SSL and terminates before it gets to this container, we need to allow `baseurlpath` to be set by an env var.

This allows us to use `https://my.reverse.proxy` as a host and base url, so that urls are not generated as `http://my.reverse.proxy`