### PR TITLE
Always release docker image as develop tag when merged to master

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,0 +1,36 @@
+name: Release docker image as develop
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-image-to-github:
+    name: Release image to GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Push to GitHub
+        run: |
+          make build RELEASE_TAGS="develop"
+          echo "${REGISTRY_TOKEN}" | docker login "${REGISTRY_HOST}" -u "${REGISTRY_USERNAME}" --password-stdin
+          make push
+        env:
+          REGISTRY_HOST: ghcr.io
+          REGISTRY_USERNAME: ${{ github.repository_owner }}
+          REGISTRY_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+
+  release-image-to-docker-hub:
+    name: Release image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Push to Docker Hub
+        run: |
+          make build RELEASE_TAGS="develop"
+          echo "${REGISTRY_TOKEN}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin
+          make push
+        env:
+          REGISTRY_HOST: index.docker.io
+          REGISTRY_USERNAME: kenchan0130
+          REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
## Changes

This change ensures that a Docker image is always released with the `develop` tag whenever there are updates to the master branch.

## Purpose

This project uses semantic versioning tags to correspond with the version of SimpleSAMLphp. However, there are users who may want to test the latest updates on the `master` branch for minor fixes or improvements immediately. This change addresses the issue of differing lifecycles for each version.